### PR TITLE
fix(dashboard): Ajusta exibição e filtro de valores de transações

### DIFF
--- a/src/app/dashboard/components/CardTransacao.tsx
+++ b/src/app/dashboard/components/CardTransacao.tsx
@@ -38,7 +38,11 @@ const CardTransacao: React.FC<Props> = (props) => {
   return (
     <styles.Card>
       <styles.CardText.Title $type={props.tipo as "deposit" | "withdraw"}>
-        {props.tipo === "deposit" ? "+" : "-"} R$ {props.valor}
+        {props.tipo === "deposit" ? "+ " : "- "}
+        {(parseInt(props.valor, 10) / 100).toLocaleString("pt-BR", {
+          style: "currency",
+          currency: "BRL",
+        })}
       </styles.CardText.Title>
 
       <styles.CardText.Common>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -116,17 +116,22 @@ const Page: React.FC = () => {
           ({ categoriaEmpresa }) => !industry || categoriaEmpresa === industry,
         )
         .filter(({ valor }) => {
-          if (!amountRange[0] && !amountRange[1]) {
+          const valorEmReais = parseInt(valor, 10) / 100;
+          const [min, max] = amountRange;
+
+          if (min === null && max === null) {
             return true;
           }
 
-          if (amountRange[0] && !amountRange[1]) {
-            return +valor >= amountRange[0];
+          if (min !== null && valorEmReais < min) {
+            return false;
           }
 
-          if (!amountRange[0] && amountRange[1]) {
-            return +valor >= amountRange[1];
+          if (max !== null && valorEmReais > max) {
+            return false;
           }
+
+          return true;
         })
         .filter(({ dataEPOCH = 0 }) => {
           if (!dateRange || !dateRange[0] || !dateRange[1]) {


### PR DESCRIPTION
A exibição dos valores nas transações agora usa o formato de moeda BRL (R$). A lógica do filtro de faixa de valores foi corrigida para converter os centavos para reais e lidar corretamente com os limites mínimo e máximo.